### PR TITLE
Upgrade Spring cloud Function - CVE-2022-22963

### DIFF
--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -85,6 +85,13 @@
     <dependencies>
       <dependency>
         <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-function-dependencies</artifactId>
+        <version>3.2.3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>
         <version>${spring-cloud.version}</version>
         <type>pom</type>


### PR DESCRIPTION
Upgrade spring cloud function dependencies to 3.2.3 to resolve [CVE-2022-22963](https://spring.io/blog/2022/03/29/cve-report-published-for-spring-cloud-function)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
