### PR TITLE
Upgrade to SpringBoot 2.6.6 - CVE-2022-22965

### DIFF
--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.3</version>
+    <version>2.6.6</version>
     <relativePath/>
   </parent>
   <groupId>software.amazonaws.example</groupId>


### PR DESCRIPTION
CVE-2022-22965: Upgrade to SpringBoot 2.6.6 (https://spring.io/blog/2022/03/31/spring-boot-2-6-6-available-now)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
