### PR TITLE
Java21update

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,26 +153,26 @@ It fits particularly well with Lambda to reduce the initialization time, but doe
             <td>244.82</td>
         </tr>
         <tr>
-            <th>Quarkus (Java 17)</th>
-            <td><b style="color: green">487.31</b></td>
-            <td><b style="color: green">586.87</b></td>
-            <td><b style="color: green">732.67</b></td>
-            <td><b style="color: green">932.17</b></td>
-            <td><b style="color: green">7.38</b></td>
-            <td><b style="color: green">11.91</b></td>
-            <td><b style="color: green">25.20</b></td>
-            <td><b style="color: green">147.26</b></td>
+            <th>Quarkus (Java 21)</th>
+            <td><b style="color: green">680.44</b></td>
+            <td><b style="color: green">812.12</b></td>
+            <td><b style="color: green">922.04</b></td>
+            <td><b style="color: green">1038.75</b></td>
+            <td><b style="color: green">7.75</b></td>
+            <td><b style="color: green">13.11</b></td>
+            <td><b style="color: green">23.84</b></td>
+            <td><b style="color: green">174.29</b></td>
         </tr>
         <tr>
-            <th>Spring Boot (Java 17)</th>
-            <td>1047.87</td>
-            <td>1200.45</td>
-            <td>1597.68</td>
-            <td>1779.53</td>
-            <td>7.62</td>
-            <td>13.01</td>
-            <td>27.73</td>
-            <td>262.25</td>
+            <th>Spring Boot (Java 21)</th>
+            <td>1085.19</td>
+            <td>1278.47</td>
+            <td>1583.38</td>
+            <td>1967.14</td>
+            <td>7.10</td>
+            <td>12.01</td>
+            <td>23.09</td>
+            <td>207.14</td>
         </tr>
 </table>
 
@@ -208,26 +208,26 @@ It fits particularly well with Lambda to reduce the initialization time, but doe
             <td>1029.55</td>
         </tr>
         <tr>
-            <th>Quarkus (22.3.r17)</th>
-            <td>467.27</td>
-            <td>599.77</td>
-            <td>802.43</td>
-            <td>1348.78</td>
-            <td>6.7</td>
-            <td>11.63</td>
-            <td>24.03</td>
-            <td>168.47</td>
+            <th>Quarkus</th>
+            <td>459.40</td>
+            <td>507.19</td>
+            <td>539.07</td>
+            <td>583.33</td>
+            <td>7.04</td>
+            <td>11.82</td>
+            <td>19.38</td>
+            <td>228.46</td>
         </tr>
         <tr>
             <th>Spring Boot</th>
-            <td>620.66</td>
-            <td>684.53</td>
-            <td>721.77</td>
-            <td>751.98</td>
-            <td>9.10</td>
-            <td>14.22</td>
-            <td>23.61</td>
-            <td>259.16</td>
+            <td>732.67</td>
+            <td>835.17</td>
+            <td>918.36</td>
+            <td>1083.40</td>
+            <td>8.53</td>
+            <td>13.54</td>
+            <td>22.01</td>
+            <td>156.96</td>
         </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -96,15 +96,15 @@ All latencies listed below are in milliseconds.
             <td><b style="color: green">231.52</b></td>
         </tr>
         <tr>
-            <th>Spring Boot (Java 17)</th>
-            <td>5311.93</td>
-            <td>5645.88</td>
-            <td>6183.47</td>
-            <td>7027.66</td>
-            <td>8.13</td>
-            <td>13.01</td>
-            <td>30.03</td>
-            <td>251.27</td>
+            <th>Spring Boot (Java 21)</th>
+            <td>5731.16</td>
+            <td>6018.84</td>
+            <td>6258.09</td>
+            <td>7011.35</td>
+            <td>8.32</td>
+            <td>13.54</td>
+            <td>26.65</td>
+            <td>174.24</td>
         </tr>
         <tr>
             <th>Dagger *</th>

--- a/README.md
+++ b/README.md
@@ -85,15 +85,15 @@ All latencies listed below are in milliseconds.
             <td>314.99</td>
         </tr>
         <tr>
-            <th>Quarkus (Java 17)</th>
-            <td><b style="color: green">2525.22</b></td>
-            <td><b style="color: green">3146.27</b></td>
-            <td><b style="color: green">4055.57</b></td>
-            <td><b style="color: green">6343.83</b></td>
-            <td><b style="color: green">7.50</b></td>
-            <td><b style="color: green">12.28</b></td>
-            <td><b style="color: green">29.87</b></td>
-            <td><b style="color: green">231.52</b></td>
+            <th>Quarkus (Java 21)</th>
+            <td><b style="color: green">2807.45</b></td>
+            <td><b style="color: green">3330.47</b></td>
+            <td><b style="color: green">4051.52</b></td>
+            <td><b style="color: green">4483.37</b></td>
+            <td><b style="color: green">8.07</b></td>
+            <td><b style="color: green">12.91</b></td>
+            <td><b style="color: green">24.61</b></td>
+            <td><b style="color: green">156.30</b></td>
         </tr>
         <tr>
             <th>Spring Boot (Java 21)</th>

--- a/quarkus/load-test/run-load-test-native.sh
+++ b/quarkus/load-test/run-load-test-native.sh
@@ -1,4 +1,4 @@
-STACK_NAME=quarkus-native-sample
+STACK_NAME=quarkus-native
 
 API_URL=$(aws cloudformation describe-stacks --stack-name $STACK_NAME \
   --query 'Stacks[0].Outputs[?OutputKey==`ApiEndpoint`].OutputValue' \

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -9,18 +9,18 @@
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>3.0.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>3.6.3</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.0.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.6.3</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.package.type>uber-jar</quarkus.package.type>
     <aws.package.name>${project.artifactId}-${project.version}-aws.jar</aws.package.name>
-    <aws.sdk2.version>2.20.42</aws.sdk2.version>
+    <aws.sdk2.version>2.20.42</aws.sdk2.version> <!-- Upgrading this to latest is causing native build to fail. So, leaving at earlier version for now.-->
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -138,7 +138,7 @@
         <quarkus.package.type>native</quarkus.package.type>
         <quarkus.native.container-build>true</quarkus.native.container-build>
         <quarkus.native.builder-image>
-          quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3-java17
+          quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:jdk-21
         </quarkus.native.builder-image>
         <quarkus.native.additional-build-args>
           --initialize-at-run-time=software.amazon.awssdk.services.dynamodb.DynamoDbRetryPolicy\,org.apache.http.impl.auth.NTLMEngineImpl\,software.amazonaws.example.product.product.dao.DynamoProductDao

--- a/quarkus/template.native.yaml
+++ b/quarkus/template.native.yaml
@@ -9,7 +9,7 @@ Globals:
     Tracing: Active
     CodeUri: target/function.zip
     Handler: not.used.in.provided.runtime
-    Runtime: provided
+    Runtime: provided.al2023
     Timeout: 30
     MemorySize: 1024
     Environment:

--- a/quarkus/template.snapstart.yaml
+++ b/quarkus/template.snapstart.yaml
@@ -9,7 +9,7 @@ Globals:
     Tracing: Active
     CodeUri: target/quarkus-lambda-function-1.0.0-SNAPSHOT-aws.jar
     Handler: io.quarkus.amazon.lambda.runtime.QuarkusStreamHandler::handleRequest
-    Runtime: java17
+    Runtime: java21
     Timeout: 30
     MemorySize: 1024
     AutoPublishAlias: live

--- a/quarkus/template.yaml
+++ b/quarkus/template.yaml
@@ -9,7 +9,7 @@ Globals:
     Tracing: Active
     CodeUri: target/quarkus-lambda-function-1.0.0-SNAPSHOT-aws.jar
     Handler: io.quarkus.amazon.lambda.runtime.QuarkusStreamHandler::handleRequest
-    Runtime: java17
+    Runtime: java21
     Timeout: 30
     MemorySize: 1024
     Environment:

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -29,17 +29,17 @@ You can learn more about SnapStart and Priming [here](https://aws.amazon.com/blo
 
 On macOS:
 ```bash
-docker run -v ~/.m2/repository:/root/.m2/repository --mount type=bind,source=$(pwd),destination=/project -it --entrypoint /bin/bash marksailes/al2-graalvm:11-22.0.0.2
+docker run -v ~/.m2/repository:/root/.m2/repository --mount type=bind,source=$(pwd),destination=/project -it --entrypoint /bin/bash dmahapatro/al2023-graalvm:21-21.0.1
 ```
 
 On macOS ARM:
 ```bash
-docker run --mount type=bind,source=$(pwd),destination=/project -it --entrypoint /bin/bash marksailes/arm64-al2-graalvm:17-22.0.0.2
+docker run -v ~/.m2/repository:/root/.m2/repository --mount type=bind,source=$(pwd),destination=/project -it --entrypoint /bin/bash aneelm/al2023-graalvm:aarm64-21-21.0.1
 ```
 
 On Windows:
 ```bash
-docker run -v <SPRING_BOOT_DIR_ABSOLUTE_PATH>:/project -it --entrypoint /bin/bash marksailes/al2-graalvm:11-22.0.0.2
+docker run -v <SPRING_BOOT_DIR_ABSOLUTE_PATH>:/project -it --entrypoint /bin/bash dmahapatro/al2023-graalvm:21-21.0.1
 ```
 Make sure to replace `SPRING_BOOT_DIR_ABSOLUTE_PATH` with an absolute path to springboot directory.
 

--- a/springboot/load-test/run-load-test-native.sh
+++ b/springboot/load-test/run-load-test-native.sh
@@ -1,4 +1,4 @@
-STACK_NAME=springboot-sample-native
+STACK_NAME=springboot-native
 
 API_URL=$(aws cloudformation describe-stacks --stack-name $STACK_NAME \
   --query 'Stacks[0].Outputs[?OutputKey==`ApiEndpoint`].OutputValue' \

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.6</version>
-    <relativePath/>
+    <version>3.2.0</version>
+    <relativePath />
   </parent>
   <groupId>software.amazonaws.example</groupId>
   <artifactId>springboot-lambda-function</artifactId>
@@ -15,16 +16,15 @@
   <description>Sample project for Spring Boot</description>
 
   <properties>
-    <java.version>17</java.version>
-    <spring-cloud.version>2022.0.2</spring-cloud.version>
-    <spring-native.version>0.12.1</spring-native.version>
+    <java.version>21</java.version>
+    <spring-cloud.version>2023.0.0</spring-cloud.version>
   </properties>
   <dependencies>
     <!-- The Following dependency is for SnapStart. This can be removed if not using SnapStart -->
     <dependency>
-      <groupId>io.github.crac</groupId>
-      <artifactId>org-crac</artifactId>
-      <version>0.1.3</version>
+      <groupId>org.crac</groupId>
+      <artifactId>crac</artifactId>
+      <version>1.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -39,11 +39,6 @@
       <artifactId>spring-cloud-function-adapter-aws</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.experimental</groupId>
-      <artifactId>spring-native</artifactId>
-      <version>${spring-native.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-core</artifactId>
       <version>1.2.2</version>
@@ -51,12 +46,12 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-events</artifactId>
-      <version>3.11.1</version>
+      <version>3.11.4</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-serialization</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.5</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
@@ -72,7 +67,8 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- X-Ray Tracing Dependencies -->
+    <!--X-Ray
+    Tracing Dependencies -->
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-xray-recorder-sdk-core</artifactId>
@@ -110,19 +106,44 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.20.51</version>
+        <version>2.22.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-xray-recorder-sdk-bom</artifactId>
-        <version>2.13.0</version>
+        <version>2.15.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.springframework.boot.experimental</groupId>
+            <artifactId>spring-boot-thin-layout</artifactId>
+            <version>1.0.31.RELEASE</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <excludes>
+            <exclude>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+            </exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>jvm</id>
@@ -136,25 +157,6 @@
             <artifactId>maven-deploy-plugin</artifactId>
             <configuration>
               <skip>true</skip>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-maven-plugin</artifactId>
-            <dependencies>
-              <dependency>
-                <groupId>org.springframework.boot.experimental</groupId>
-                <artifactId>spring-boot-thin-layout</artifactId>
-                <version>1.0.28.RELEASE</version>
-              </dependency>
-            </dependencies>
-            <configuration>
-              <excludes>
-                <exclude>
-                  <groupId>org.projectlombok</groupId>
-                  <artifactId>lombok</artifactId>
-                </exclude>
-              </excludes>
             </configuration>
           </plugin>
           <plugin>
@@ -179,34 +181,14 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.springframework.experimental</groupId>
-            <artifactId>spring-aot-maven-plugin</artifactId>
-            <version>${spring-native.version}</version>
-            <executions>
-              <execution>
-                <id>test-generate</id>
-                <goals>
-                  <goal>test-generate</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>generate</id>
-                <goals>
-                  <goal>generate</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>0.9.19</version>
             <extensions>true</extensions>
             <executions>
               <execution>
                 <id>build-native</id>
                 <goals>
-                  <goal>build</goal>
+                  <goal>compile-no-fork</goal>
                 </goals>
                 <phase>package</phase>
               </execution>
@@ -250,16 +232,16 @@
   </profiles>
   <repositories>
     <repository>
-      <id>spring-release</id>
-      <name>Spring release</name>
-      <url>https://repo.spring.io/release</url>
+      <id>spring-milestone</id>
+      <name>Spring milestone</name>
+      <url>https://repo.spring.io/milestone</url>
     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
-      <id>spring-release</id>
-      <name>Spring release</name>
-      <url>https://repo.spring.io/release</url>
+      <id>spring-milestone</id>
+      <name>Spring milestone</name>
+      <url>https://repo.spring.io/milestone</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/springboot/src/main/java/software/amazonaws/example/product/product/SpringBootSampleApplication.java
+++ b/springboot/src/main/java/software/amazonaws/example/product/product/SpringBootSampleApplication.java
@@ -3,41 +3,23 @@
 
 package software.amazonaws.example.product.product;
 
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.amazonaws.xray.entities.TraceHeader;
-import com.amazonaws.xray.entities.TraceID;
-import com.amazonaws.xray.interceptors.TracingInterceptor;
 import org.joda.time.DateTime;
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import software.amazonaws.example.product.product.entity.Product;
 import software.amazonaws.example.product.product.entity.Products;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.nativex.hint.TypeAccess;
-import org.springframework.nativex.hint.TypeHint;
-
-import java.util.HashSet;
 
 @SpringBootApplication
-@TypeHint(types = {
-  DateTime.class,
-  APIGatewayProxyRequestEvent.class,
-  TracingInterceptor.class,
-  HashSet.class,
-  TraceHeader.class,
-  TraceID.class
-},
-  typeNames = {
-    "com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent$ProxyRequestContext",
-    "com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent$RequestIdentity",
-    "com.amazonaws.xray.entities.TraceHeader$SampleDecision"
-  })
-@TypeHint(
-  types = { Product.class, Products.class}, access = { TypeAccess.PUBLIC_CONSTRUCTORS, TypeAccess.PUBLIC_METHODS }
-)
+@RegisterReflectionForBinding({DateTime.class, APIGatewayProxyRequestEvent.class, Product.class, Products.class})
+
 public class SpringBootSampleApplication {
 
-  public static void main(String[] args) {
-    SpringApplication.run(SpringBootSampleApplication.class, args);
+    public static void main(String[] args) {
+      SpringApplication.run(SpringBootSampleApplication.class, args);
+    }
+    
   }
-}
+  

--- a/springboot/template.native.arm64.yaml
+++ b/springboot/template.native.arm64.yaml
@@ -11,7 +11,7 @@ Globals:
     Tracing: Active
     CodeUri: target/function-native-zip.zip
     Handler: org.springframework.cloud.function.adapter.aws.SpringBootStreamHandler
-    Runtime: provided.al2
+    Runtime: provided.al2023
     Timeout: 30
     MemorySize: 1024
     Environment:
@@ -30,7 +30,7 @@ Resources:
     Properties:
       Environment:
         Variables:
-          DEFAULT_HANDLER: getProductById
+          SPRING_CLOUD_FUNCTION_DEFINITION: getProductByIdFunction
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref ProductsTable
@@ -47,7 +47,7 @@ Resources:
     Properties:
       Environment:
         Variables:
-          DEFAULT_HANDLER: getAllProducts
+          SPRING_CLOUD_FUNCTION_DEFINITION: getAllProductsFunction
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref ProductsTable
@@ -64,7 +64,7 @@ Resources:
     Properties:
       Environment:
         Variables:
-          DEFAULT_HANDLER: createProduct
+          SPRING_CLOUD_FUNCTION_DEFINITION: createProductFunction
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref ProductsTable
@@ -81,7 +81,7 @@ Resources:
     Properties:
       Environment:
         Variables:
-          DEFAULT_HANDLER: deleteProduct
+          SPRING_CLOUD_FUNCTION_DEFINITION: deleteProductFunction
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref ProductsTable

--- a/springboot/template.native.yaml
+++ b/springboot/template.native.yaml
@@ -9,7 +9,7 @@ Globals:
     Tracing: Active
     CodeUri: target/function-native-zip.zip
     Handler: org.springframework.cloud.function.adapter.aws.FunctionInvoker::handleRequest
-    Runtime: provided
+    Runtime: provided.al2023
     Timeout: 30
     MemorySize: 1024
     Environment:

--- a/springboot/template.snapstart.yaml
+++ b/springboot/template.snapstart.yaml
@@ -9,7 +9,7 @@ Globals:
     Tracing: Active
     CodeUri: target/springboot-lambda-function-1.0.0-SNAPSHOT-aws.jar
     Handler: org.springframework.cloud.function.adapter.aws.FunctionInvoker::handleRequest
-    Runtime: java17
+    Runtime: java21
     Timeout: 30
     MemorySize: 1024
     AutoPublishAlias: live

--- a/springboot/template.yaml
+++ b/springboot/template.yaml
@@ -9,7 +9,7 @@ Globals:
     Tracing: Active
     CodeUri: target/springboot-lambda-function-1.0.0-SNAPSHOT-aws.jar
     Handler: org.springframework.cloud.function.adapter.aws.FunctionInvoker::handleRequest
-    Runtime: java17
+    Runtime: java21
     Timeout: 30
     MemorySize: 1024
     Environment:


### PR DESCRIPTION
Updated Spring Boot and Quarkus to latest versions of the corresponding frameworks and JDK 21. Also upgraded custom runtime for graalvm examples to al2023.
Micronaut update is pending resolution of this graalvm and java21 issue - https://github.com/micronaut-projects/micronaut-core/issues/10046

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
